### PR TITLE
Release v0.0.10

### DIFF
--- a/clients/appointments/package.json
+++ b/clients/appointments/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@canvas-medical/embed-appointments",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": false,
   "main": "dist/appointments.js",
   "license": "MIT",
   "scripts": {
     "build": "webpack build --env prod",
     "build:esm": "webpack build --env prod --env esm",
+    "gitpkg": "gitpkg publish --registry git@github.com:modern-age/canvas-embed.git",
     "start": "webpack server --open",
     "test": "TZ=UTC jest ./tests",
     "test:update": "yarn test --updateSnapshot"

--- a/clients/common/package.json
+++ b/clients/common/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@canvas-medical/embed-common",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": false,
   "main": "src/index.ts",
   "scripts": {
     "build:esm": "webpack build",
+    "gitpkg": "gitpkg publish --registry git@github.com:modern-age/canvas-embed.git",
     "start": "echo 'No Start Provided'",
     "test": "TZ=UTC jest ./tests",
     "test:update": "yarn test --updateSnapshot"

--- a/clients/scheduler/package.json
+++ b/clients/scheduler/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@canvas-medical/embed-scheduler",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": false,
   "main": "dist/scheduler.js",
   "license": "MIT",
   "scripts": {
     "build": "webpack build --env prod",
     "build:esm": "webpack build --env prod --env esm",
+    "gitpkg": "gitpkg publish --registry git@github.com:modern-age/canvas-embed.git",
     "prepare": "npm run build",
     "start": "webpack server --open",
     "test": "TZ=UTC jest ./tests",


### PR DESCRIPTION
Release v0.0.10

Bumps the version number so that we can use `gitpkg` to publish new tags for each package.

**One time deal**: adding a `gitpkg` script so that we can do the following to generate release packages/tags like so
```
cd clients
npm run gitpkg --workspaces
```

Normally a release PR in this repo will just be bumping package version numbers.