### PR TITLE
Add 'prepack' lifecycle hooks

### DIFF
--- a/clients/appointments/package.json
+++ b/clients/appointments/package.json
@@ -8,6 +8,7 @@
     "build": "webpack build --env prod",
     "build:esm": "webpack build --env prod --env esm",
     "gitpkg": "gitpkg publish --registry git@github.com:modern-age/canvas-embed.git",
+    "prepack": "npm run build",
     "start": "webpack server --open",
     "test": "TZ=UTC jest ./tests",
     "test:update": "yarn test --updateSnapshot"

--- a/clients/common/package.json
+++ b/clients/common/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build:esm": "webpack build",
     "gitpkg": "gitpkg publish --registry git@github.com:modern-age/canvas-embed.git",
+    "prepack": "npm run build:esm",
     "start": "echo 'No Start Provided'",
     "test": "TZ=UTC jest ./tests",
     "test:update": "yarn test --updateSnapshot"

--- a/clients/scheduler/package.json
+++ b/clients/scheduler/package.json
@@ -8,7 +8,7 @@
     "build": "webpack build --env prod",
     "build:esm": "webpack build --env prod --env esm",
     "gitpkg": "gitpkg publish --registry git@github.com:modern-age/canvas-embed.git",
-    "prepare": "npm run build",
+    "prepack": "npm run build",
     "start": "webpack server --open",
     "test": "TZ=UTC jest ./tests",
     "test:update": "yarn test --updateSnapshot"


### PR DESCRIPTION
We need to use npm's `prepack` lifecycle hook to in order to run Webpack everytime we publish with `gitpkg`.

Also, removed the `prepare` lifecycle hook from the scheduler package. It causes issues when using it in `jade`.