### PR TITLE
Release embed-scheduler v0.0.11

### DIFF
--- a/clients/scheduler/CHANGELOG.md
+++ b/clients/scheduler/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## [0.0.10] - 2022-05-11
+
+### Added
+
+- Added a `daysToFetch` prop with a default value of 7
+- Support bulk fetching of time slots
+
+### Changed
+
+- Paginate via previously loaded (locally stored) time slots instead of fetching new time slots each time the date updates
+
+## [0.0.11] - 2022-05-12
+
+### Fixed
+
+- Fixed a bug that prevented `maxDate` from being stored when 1 or more providers has no time slots

--- a/clients/scheduler/package.json
+++ b/clients/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canvas-medical/embed-scheduler",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": false,
   "main": "dist/scheduler.js",
   "license": "MIT",

--- a/clients/scheduler/src/components/time-slot-select/index.tsx
+++ b/clients/scheduler/src/components/time-slot-select/index.tsx
@@ -35,8 +35,12 @@ export const TimeSlotSelect = () => {
     })
 
     const maxDateSlot = providersMaxDates.reduce((a, b) => {
-      if (!a || !b) {
+      if (!a && !b) {
         return undefined
+      } else if (!a) {
+        return b
+      } else if (!b) {
+        return a
       }
 
       return new Date(a.start) > new Date(b.start) ? a : b;


### PR DESCRIPTION
Release v0.0.11

Primarily a bugfix for storing `maxDate` even when multiple providers have no availability