### PR TITLE
Update Scheduler to appear more clickable

### DIFF
--- a/clients/scheduler/src/components/date-select/arrow-down.tsx
+++ b/clients/scheduler/src/components/date-select/arrow-down.tsx
@@ -1,0 +1,16 @@
+import { h } from 'preact'
+
+export const ArrowDown = () => (
+  <svg
+    fill="none"
+    height="8"
+    viewBox="0 0 14 8"
+    width="14"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M1 1L7 7L13 1"
+      stroke-width="2"
+    />
+  </svg>
+)

--- a/clients/scheduler/src/components/date-select/index.tsx
+++ b/clients/scheduler/src/components/date-select/index.tsx
@@ -4,7 +4,6 @@ import {
   ArrowBack,
   ArrowForward,
   Box,
-  Calendar as CalendarIcon,
   formatDate,
   H2,
   Span,
@@ -16,6 +15,7 @@ import {
   scrollDateForward,
   userTimezone,
 } from '../../utils'
+import { ArrowDown } from './arrow-down'
 import { DateViewContainer, DateScrollButton, DateSelectButton } from './styles'
 import { Calendar } from './calendar'
 
@@ -56,10 +56,10 @@ export const DateSelect = () => {
             hc={colors.accent.hover}
             onClick={() => setCalendarOpen(true)}
           >
-            <CalendarIcon />
             <Box ml="10px" maxWidth="fit-content">
               <H2>{formatDate(date)}</H2>
             </Box>
+            <ArrowDown />
           </DateSelectButton>
 
           <DateScrollButton

--- a/clients/scheduler/src/components/date-select/styles.ts
+++ b/clients/scheduler/src/components/date-select/styles.ts
@@ -61,13 +61,16 @@ export const DateSelectButton = styled.button<HoverColorPropType>`
   display: flex;
   flex-grow: 1;
   justify-content: center;
+  stroke: #000;
+
+  div {
+    margin-right: .5rem;
+  }
 
   &:hover {
+    stroke: ${p => p.hc};
     h2 {
       color: ${p => p.hc};
-    }
-    path {
-      fill: ${p => p.hc};
     }
   }
 `


### PR DESCRIPTION
Making the date header in the scheduler appear clickable by removing the calendar icon before the date in favor of a dropdown-style arrow after the date