### PR TITLE
Prevent booking before current time or one house after current time

### DIFF
--- a/clients/scheduler/src/components/time-slot-select/index.tsx
+++ b/clients/scheduler/src/components/time-slot-select/index.tsx
@@ -56,11 +56,16 @@ slots.sort((slot1, slot2) => {
   }, [date])
 
   const dayOfTimeSlots = useMemo(() => {
+    const earliestAvailable = new Date();
+    //appointments within one hour can not be booked
+    earliestAvailable.setTime(earliestAvailable.getTime() + (60*60*1000));
+
     return providerTimeSlots.map((provider) => {
       return {
         providerId: provider.providerId,
         providerSlots: provider.providerSlots.filter((slot) => {
-          return isSameDay(new Date(slot.start), date)
+          const startDate = new Date(slot.start);
+          return isSameDay(startDate, date) && startDate > earliestAvailable
         })
       }
     })


### PR DESCRIPTION
Hide the appointment if its start time is in the past or within 1 hour from now.