### PR TITLE
Filter off past appointments before minDate is selected

### DIFF
--- a/clients/scheduler/src/components/time-slot-select/index.tsx
+++ b/clients/scheduler/src/components/time-slot-select/index.tsx
@@ -4,18 +4,19 @@ import { useState, useEffect, useMemo, useCallback } from 'preact/hooks'
 import { useAppContext } from '../../hooks'
 import { Ui } from './ui'
 
+const ONE_MINUTE_IN_MILLISECONDS = 60*1000
+
 export const TimeSlotSelect = () => {
-  const { fetchTimeSlots, date, setDate } = useAppContext()
+  const { fetchTimeSlots, date, setDate, appointmentBufferInMintues } = useAppContext()
   const [providerTimeSlots, setProviderTimeSlots] = useState<ParsedSlotsType[]>([])
 
   const addTimeSlots = useCallback((newProviderTimeSlots: ParsedSlotsType[]) => {
     const earliestAvailable = new Date();
-    //appointments within one hour can not be booked
-    earliestAvailable.setTime(earliestAvailable.getTime() + (60*60*1000));
+    earliestAvailable.setTime(earliestAvailable.getTime() + (appointmentBufferInMintues*ONE_MINUTE_IN_MILLISECONDS));
 
     const mergedProviderAvailability = newProviderTimeSlots.map((newProvider) => {
       const provider = providerTimeSlots.find((entry) => entry.providerId === newProvider.providerId)
-      const availableSlots = newProvider.providerSlots.filter(slot => new Date(slot.start) > earliestAvailable)
+      const availableSlots = newProvider.providerSlots.filter(slot => new Date(slot.start) >= earliestAvailable)
       const mergedSlots = provider ? [...provider.providerSlots, ...availableSlots] : availableSlots
       return {providerId: newProvider.providerId, providerSlots: mergedSlots}
     })

--- a/clients/scheduler/src/hooks/app-context.tsx
+++ b/clients/scheduler/src/hooks/app-context.tsx
@@ -19,6 +19,7 @@ type ContextWrapperProps = {
 
 export const AppContext = createContext<IAppContext>({
   api: '',
+  appointmentBufferInMintues: 60,
   appointmentCoding: {},
   bailoutURL: '',
   daysToFetch: 7,

--- a/clients/scheduler/src/index.tsx
+++ b/clients/scheduler/src/index.tsx
@@ -8,6 +8,7 @@ import { hasAllValues, IInitializerProps, ISchedulerProps } from './utils'
 export const Scheduler = (props: ISchedulerProps) => {
   const {
     api,
+    appointmentBufferInMintues,
     appointmentCoding,
     bailoutURL,
     daysToFetch,
@@ -34,6 +35,7 @@ export const Scheduler = (props: ISchedulerProps) => {
         <ContextWrapper
           values={{
             api,
+            appointmentBufferInMintues,
             appointmentCoding,
             bailoutURL,
             duration,
@@ -82,6 +84,7 @@ export const Scheduler = (props: ISchedulerProps) => {
 
 export const init = ({
   api,
+  appointmentBufferInMintues = 60,
   appointmentCoding,
   bailoutURL,
   duration,
@@ -120,6 +123,7 @@ export const init = ({
   render(
     <Scheduler
       api={api}
+      appointmentBufferInMintues={appointmentBufferInMintues}
       appointmentCoding={appointmentCoding}
       bailoutURL={bailoutURL}
       daysToFetch={daysToFetch}

--- a/clients/scheduler/src/utils/types.ts
+++ b/clients/scheduler/src/utils/types.ts
@@ -8,6 +8,7 @@ import {
 
 export interface IMainAppProps {
   api: string
+  appointmentBufferInMintues: number
   appointmentCoding: AppointmentCodingType
   bailoutURL: string
   daysToFetch: number


### PR DESCRIPTION
[Previous solution](https://github.com/modern-age/canvas-embed/pull/9) broke skip to first available date if all appointment times that day were in the past - past appointments need to be removed before the first available date is selected