### PR TITLE
ACAI-1063: Add callbacks for various events in the scheduler

### DIFF
--- a/clients/appointments/src/utils/types.ts
+++ b/clients/appointments/src/utils/types.ts
@@ -1,9 +1,8 @@
-import { CallbackType, GeneratedColorsType } from '@canvas-medical/embed-common'
+import { GeneratedColorsType } from '@canvas-medical/embed-common'
 
 export interface IMainAppProps {
   api: string
   bailoutURL: string
-  callbacks: Record<string, CallbackType>
   locationId: string
   patientId: string
   patientKey: string

--- a/clients/common/src/components/cancellation-display/index.tsx
+++ b/clients/common/src/components/cancellation-display/index.tsx
@@ -22,7 +22,8 @@ export const CancellationDisplay = ({
           bc={colors.destructive.main}
           hc={colors.destructive.hover}
           fc={colors.destructive.font}
-          onClick={() => onCancel()}
+          data-analytics-id="cancellation-display-close"
+          onClick={e => onCancel(e)}
         >
           Yes, cancel it
         </Button>
@@ -30,7 +31,8 @@ export const CancellationDisplay = ({
           bc={colors.secondary.main}
           hc={colors.secondary.hover}
           fc={colors.secondary.font}
-          onClick={() => onKeep()}
+          data-analytics-id="cancellation-display-keep"
+          onClick={e => onKeep(e)}
         >
           No, keep it
         </Button>

--- a/clients/common/src/utils/types/index.ts
+++ b/clients/common/src/utils/types/index.ts
@@ -41,8 +41,3 @@ export type AppointmentCodingType = {
   code?: string
   display?: string
 }
-
-export type CallbackType = {
-  eventName: string
-  callback: () => void
-}

--- a/clients/scheduler/src/components/confirmation/index.tsx
+++ b/clients/scheduler/src/components/confirmation/index.tsx
@@ -28,6 +28,7 @@ export const Confirmation = () => {
     fetchScheduledAppointment,
     shadowRoot,
     setScreen,
+    callbacks: { onClick },
   } = useAppContext()
   const [appointmentId, setAppointmentId] = useState(null)
   const [popoverOpen, setPopoverOpen] = useState(false)
@@ -36,10 +37,26 @@ export const Confirmation = () => {
     fetchScheduledAppointment(setAppointmentId)
   }, [fetchScheduledAppointment])
 
-  const handleCancel = () => {
+  const handleCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (appointmentId) {
       cancelAppointment(appointmentId, () => setScreen('SELECT'))
     }
+    onClick(e)
+  }
+
+  const handleKeep = (e: React.MouseEvent<HTMLButtonElement>) => {
+    setPopoverOpen(false)
+    onClick(e)
+  }
+
+  const handleCancelClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    setPopoverOpen(true)
+    onClick(e)
+  }
+
+  const handleFinishClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onClick(e)
+    window.location.href = returnURL
   }
 
   const appointmentDate = new Date(timeSlot.start)
@@ -71,7 +88,8 @@ export const Confirmation = () => {
               bc={colors.accent.main}
               hc={colors.accent.hover}
               fc={colors.accent.font}
-              onClick={() => setPopoverOpen(true)}
+              data-analytics-id="appointment-confirmation-cancel"
+              onClick={e => handleCancelClick(e)}
             >
               Cancel
             </Button>
@@ -83,7 +101,8 @@ export const Confirmation = () => {
             bc={colors.accent.main}
             hc={colors.accent.hover}
             fc={colors.accent.font}
-            onClick={() => (window.location.href = returnURL)}
+            data-analytics-id="appointment-confirmation-finish"
+            onClick={e => handleFinishClick(e)}
           >
             Finish
           </Button>
@@ -95,10 +114,7 @@ export const Confirmation = () => {
         open={popoverOpen}
         titleId={'cancel-appointment'}
       >
-        <CancellationDisplay
-          onCancel={handleCancel}
-          onKeep={() => setPopoverOpen(false)}
-        />
+        <CancellationDisplay onCancel={handleCancel} onKeep={handleKeep} />
       </Popover>
     </Fragment>
   )

--- a/clients/scheduler/src/components/date-select/calendar/index.tsx
+++ b/clients/scheduler/src/components/date-select/calendar/index.tsx
@@ -16,8 +16,17 @@ type CalendarPropsType = {
   maxDate?: Date
 }
 
-export const Calendar = ({ open, close, enabledDates, maxDate }: CalendarPropsType) => {
-  const { callbacks: { onBookingDateChange }, date, providerIds, setDate } = useAppContext()
+export const Calendar = ({
+  open,
+  close,
+  enabledDates,
+  maxDate,
+}: CalendarPropsType) => {
+  const {
+    callbacks: { onClick },
+    date,
+    setDate,
+  } = useAppContext()
   const monthsAndYears = getMonthAndYearOptions()
 
   const backDisabled = sameMonthAndYear(date, monthsAndYears[0].date)
@@ -26,15 +35,22 @@ export const Calendar = ({ open, close, enabledDates, maxDate }: CalendarPropsTy
     monthsAndYears[monthsAndYears.length - 1].date
   )
 
-  const navigateForward = () => {
-    setDate(getNextMonth(date))
+  const navigateForward = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const newDate = getNextMonth(date)
+    setDate(newDate)
+    onClick(e, { date: newDate })
   }
 
-  const navigateBack = () => {
-    setDate(getPreviousMonth(date))
+  const navigateBack = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const newDate = getPreviousMonth(date)
+    setDate(newDate)
+    onClick(e, { date: newDate })
   }
 
-  const handleDateChange = (day: number) => {
+  const handleDateChange = (
+    e: React.MouseEvent<HTMLButtonElement>,
+    day: number
+  ) => {
     const month = date.getMonth()
     const year = date.getFullYear()
 
@@ -45,8 +61,7 @@ export const Calendar = ({ open, close, enabledDates, maxDate }: CalendarPropsTy
     }
 
     setDate(newDate)
-    onBookingDateChange({ direction: "", date: newDate, providerIds })
-
+    onClick(e, { date: newDate })
     close()
   }
 

--- a/clients/scheduler/src/components/date-select/calendar/ui.tsx
+++ b/clients/scheduler/src/components/date-select/calendar/ui.tsx
@@ -1,4 +1,3 @@
-import { h } from 'preact'
 import {
   ArrowBack,
   ArrowForward,
@@ -52,10 +51,25 @@ export const Ui = ({
   handleDateChange,
   monthsAndYears,
 }: CalendarUiPropsType) => {
-  const { colors, date, setDate, shadowRoot } = useAppContext()
+  const {
+    colors,
+    date,
+    setDate,
+    shadowRoot,
+    callbacks: { onChange, onClick },
+  } = useAppContext()
   const days = generateDays(date, enabledDates, maxDate)
   const skipppedDays = getSkipDays(date)
   const dayMarkers = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+  const handleMonthChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newDate = new Date(e.target.value)
+    setDate(newDate)
+    onChange(e, { date: newDate })
+  }
+  const handleCalendarClose = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onClick(e)
+    close()
+  }
 
   return (
     <FocusTrapBackdrop open={open} shadowRoot={shadowRoot} zIndex={2000}>
@@ -73,7 +87,8 @@ export const Ui = ({
           </CalendarHeaderBox>
           <IconButton
             aria-label="Close Calendar"
-            onClick={() => close()}
+            onClick={e => handleCalendarClose(e)}
+            data-analytics-id="calendar-close"
             tabIndex={-1}
             mr="8px"
             ml="auto"
@@ -91,8 +106,9 @@ export const Ui = ({
         <MonthBox>
           <MonthSelect
             // value={getMonthAndYearString(date)}
-            onChange={e => setDate(new Date(e.target.value))}
             autoFocus
+            data-analytics-id="calendar-month-select"
+            onChange={handleMonthChange}
           >
             {monthsAndYears.map(monthAndYear => (
               <option
@@ -109,7 +125,8 @@ export const Ui = ({
             disabled={backDisabled}
             ml="auto"
             mr="8px"
-            onClick={() => navigateBack()}
+            onClick={e => navigateBack(e)}
+            data-analytics-id="calendar-month-back"
             aria-label="Previous Month"
             fc={colors.brand.main}
             hc={colors.brand.hover}
@@ -121,7 +138,8 @@ export const Ui = ({
             disabled={forwardDisabled}
             ml="4px"
             mr="24px"
-            onClick={() => navigateForward()}
+            onClick={e => navigateForward(e)}
+            data-analytics-id="calendar-month-forward"
             aria-label="Next Month"
             fc={colors.brand.main}
             hc={colors.brand.hover}
@@ -149,7 +167,8 @@ export const Ui = ({
                   fc={colors.accent.font}
                   disabled={day.disabled}
                   selected={day.date === date.getDate()}
-                  onClick={() => handleDateChange(day.date)}
+                  data-analytics-id="calendar-date-select"
+                  onClick={e => handleDateChange(e, day.date)}
                 >
                   {day.date}
                 </CalendarDateButton>

--- a/clients/scheduler/src/components/date-select/index.tsx
+++ b/clients/scheduler/src/components/date-select/index.tsx
@@ -24,8 +24,13 @@ type DateSelectPropsType = {
   maxDate?: Date
 }
 
-export const DateSelect = ({ enabledDates, maxDate }: DateSelectPropsType)=> {
-  const { callbacks: { onBookingDateChange }, colors, date, providerIds, setDate } = useAppContext()
+export const DateSelect = ({ enabledDates, maxDate }: DateSelectPropsType) => {
+  const {
+    callbacks: { onClick },
+    colors,
+    date,
+    setDate,
+  } = useAppContext()
   const [calendarOpen, setCalendarOpen] = useState(false)
   const backDisabled = isTodayOrBefore(date)
 
@@ -42,13 +47,27 @@ export const DateSelect = ({ enabledDates, maxDate }: DateSelectPropsType)=> {
     }
   }, [])
 
-  const onClick = (direction) => {
-    if (direction === "back") {
-      scrollDateBack(date, setDate)
-    } else {
-      scrollDateForward(date, setDate)
+  const handleDateScrollClick = (
+    e: React.MouseEvent<HTMLButtonElement>,
+    direction: string
+  ) => {
+    const callback = (newDate: Date) => {
+      setDate(newDate)
+      onClick(e, { direction, date: newDate })
     }
-    onBookingDateChange({ direction, date, providerIds })
+    if (direction === 'back') {
+      scrollDateBack(date, callback)
+    } else {
+      scrollDateForward(date, callback)
+    }
+  }
+
+  const handleCalendarToggle = (
+    e: React.MouseEvent<HTMLButtonElement>,
+    isCalendarOpen: boolean
+  ) => {
+    setCalendarOpen(isCalendarOpen)
+    onClick(e, { open: isCalendarOpen })
   }
 
   return (
@@ -60,7 +79,8 @@ export const DateSelect = ({ enabledDates, maxDate }: DateSelectPropsType)=> {
             fc={colors.accent.main}
             hc={colors.accent.hover}
             disabled={backDisabled}
-            onClick={() => onClick("back")}
+            data-analytics-id="scroll-date-back"
+            onClick={e => handleDateScrollClick(e, 'back')}
           >
             <ArrowBack />
           </DateScrollButton>
@@ -68,7 +88,8 @@ export const DateSelect = ({ enabledDates, maxDate }: DateSelectPropsType)=> {
           <DateSelectButton
             aria-label="Open Date Picker"
             hc={colors.accent.hover}
-            onClick={() => setCalendarOpen(true)}
+            data-analytics-id="scroll-date-calendar-toggle"
+            onClick={e => handleCalendarToggle(e, true)}
           >
             <Box ml="10px" maxWidth="fit-content">
               <H2>{formatDate(date)}</H2>
@@ -80,7 +101,8 @@ export const DateSelect = ({ enabledDates, maxDate }: DateSelectPropsType)=> {
             aria-label="Scroll Date Forward"
             fc={colors.accent.main}
             hc={colors.accent.hover}
-            onClick={() => onClick("forward")}
+            data-analytics-id="scroll-date-forward"
+            onClick={e => handleDateScrollClick(e, 'forward')}
           >
             <ArrowForward />
           </DateScrollButton>
@@ -90,7 +112,12 @@ export const DateSelect = ({ enabledDates, maxDate }: DateSelectPropsType)=> {
           <Span fontSize="0.875rem">{`Appointment times shown in ${userTimezone}`}</Span>
         </Box>
       </Box>
-      <Calendar open={calendarOpen} close={() => setCalendarOpen(false)} enabledDates={enabledDates} maxDate={maxDate} />
+      <Calendar
+        open={calendarOpen}
+        close={() => setCalendarOpen(false)}
+        enabledDates={enabledDates}
+        maxDate={maxDate}
+      />
     </Fragment>
   )
 }

--- a/clients/scheduler/src/components/time-slot-select/confirm-appointment.tsx
+++ b/clients/scheduler/src/components/time-slot-select/confirm-appointment.tsx
@@ -17,21 +17,26 @@ type ConfirmAppointmentType = {
 }
 
 export const ConfirmAppointment = ({ onCancel }: ConfirmAppointmentType) => {
-  const { callbacks, loading, timeSlot, appointmentCoding, date, createAppointment } =
-    useAppContext()
-  const { onBookingCanceled, onBookingConfirmed } = callbacks
+  const {
+    loading,
+    timeSlot,
+    appointmentCoding,
+    date,
+    createAppointment,
+    callbacks: { onClick },
+  } = useAppContext()
 
   const display =
     appointmentCoding.display ||
     getAppointmentType(appointmentCoding.code || '')
 
-  const onClickConfirm = () => {
+  const onClickConfirm = (e: React.MouseEvent<HTMLButtonElement>) => {
     createAppointment()
-    onBookingConfirmed(timeSlot)
+    onClick(e)
   }
-  const onClickCancel = () => {
+  const onClickCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
     onCancel()
-    onBookingCanceled(timeSlot)
+    onClick(e)
   }
 
   return (
@@ -60,7 +65,8 @@ export const ConfirmAppointment = ({ onCancel }: ConfirmAppointmentType) => {
           bc={appColors.primary.main}
           hc={appColors.primary.hover}
           fc={appColors.primary.font}
-          onClick={() => onClickConfirm()}
+          data-analytics-id="confirm-appointmet"
+          onClick={e => onClickConfirm(e)}
           disabled={loading}
         >
           Confirm
@@ -69,7 +75,8 @@ export const ConfirmAppointment = ({ onCancel }: ConfirmAppointmentType) => {
           bc={appColors.secondary.main}
           hc={appColors.secondary.hover}
           fc={appColors.secondary.font}
-          onClick={() => onClickCancel()}
+          data-analytics-id="cancel-confirm-appointmet"
+          onClick={e => onClickCancel(e)}
         >
           Cancel
         </Button>

--- a/clients/scheduler/src/components/time-slot-select/time-slots.tsx
+++ b/clients/scheduler/src/components/time-slot-select/time-slots.tsx
@@ -22,11 +22,17 @@ export const TimeSlots = ({
   slots,
   selectTimeSlot,
 }: TimeSlotsType) => {
-  const { colors, callbacks: { onBookingTimeSlotSelected }, setTimeSlot } = useAppContext()
+  const {
+    colors,
+    callbacks: { onClick },
+  } = useAppContext()
 
-  const onClick = ({ start, end }) => {
+  const handleTimeSlotClick = (
+    e: React.MouseEvent<HTMLButtonElement>,
+    { start, end }: { start: string; end: string }
+  ) => {
     selectTimeSlot({ end, provider, start })
-    onBookingTimeSlotSelected({ end, provider, start })
+    onClick(e, { end, provider, start })
   }
 
   return (
@@ -36,13 +42,14 @@ export const TimeSlots = ({
       </Box>
       {slots.length ? (
         <TimeSlotList>
-          {slots.map((slot) => (
+          {slots.map(slot => (
             <TimeSlotButton
               id={slot.start}
               bc={colors.accent.main}
               hc={colors.accent.hover}
               fc={colors.accent.font}
-              onClick={() => onClick(slot)}
+              data-analytics-id="timeslot-button"
+              onClick={e => handleTimeSlotClick(e, slot)}
             >
               <ScreenReaderText>Select time slot for</ScreenReaderText>
               {`${formatTime(slot.start)} - ${formatTime(slot.end)}`}

--- a/clients/scheduler/src/hooks/app-context.tsx
+++ b/clients/scheduler/src/hooks/app-context.tsx
@@ -23,11 +23,10 @@ export const AppContext = createContext<IAppContext>({
   appointmentCoding: {},
   bailoutURL: '',
   callbacks: {
-    onBookingConfirmed: () => {},
+    onClick: () => {},
+    onChange: () => {},
+    onError: () => {},
     onBookingError: () => {},
-    onBookingTimeSlotSelected: () => {},
-    onBookingCanceled: () => {},
-    onBookingDateChange: () => {},
   },
   daysToFetch: 7,
   duration: 20,
@@ -128,9 +127,9 @@ export const ContextWrapper = ({ children, values }: ContextWrapperProps) => {
   const createAppointment = useCallback(() => {
     postAppointment({
       setScreen: () => setScreen('CONFIRM'),
-      setError: (msg) => { 
-        values.callbacks.onBookingError(msg) 
-        setError(msg) 
+      setError: msg => {
+        values.callbacks.onBookingError(msg)
+        setError(msg)
       },
       setLoading,
       appointmentCoding: values.appointmentCoding,

--- a/clients/scheduler/src/index.html
+++ b/clients/scheduler/src/index.html
@@ -21,68 +21,78 @@
     <div id="embed-root"></div>
     <script src="./scheduler.js" type="text/javascript"></script>
     <script type="text/javascript">
-
       const callbacks = {
-        onBookingConfirmed: (e) => {
-          console.log("onBookingConfirmed", e)
+        onClick: (e, config) => {
+          if (e && e.target) {
+            // Prescribed method for getting the element clicked
+            // const closestTarget = e.target.closest('[data-analytics-id]')
+            // console.log(
+            //   closestTarget.dataset,
+            //   'e.target.dataset',
+            //   config,
+            //   'config'
+            // )
+          }
         },
-        onBookingError: (e) => {
-          console.log("onBookingError", e)
+        onChange: (e, config) => {
+          if (e && e.target) {
+            // const closestTarget = e.target.closest('[data-analytics-id]')
+            // console.log(
+            //   closestTarget.dataset,
+            //   'e.target.dataset',
+            //   config,
+            //   'config'
+            // )
+          }
         },
-        onBookingTimeSlotSelected: (e) => {
-          console.log("onBookingTimeSlotSelected", e)
-        },
-        onBookingCanceled: (e) => {
-          console.log("onBookingCanceled", e)
-        },
-        onBookingDateChange: (e) => {  
-          console.log("onBookingDateChange", e)
-        }
+        onError: config => {},
       }
 
       const config = {
-        apiKey: "API_KEY",
-        patientId: "PATIENT_ID",
-        providerIds: [
-          'PROVIDER_ID',
-        ]
+        apiKey: 'API_KEY',
+        patientId: 'PATIENT_ID',
+        providerIds: ['PROVIDER_ID'],
       }
 
       // This is the URL of the running proxy container
-      const apiBaseUrl = "http://localhost:3000"
+      const apiBaseUrl = 'http://localhost:3000'
 
-      fetch(`${apiBaseUrl}/Auth?` + new URLSearchParams({
-        key: config.apiKey,
-        patient: config.patientId
-      }))
-      .then(res => res.json())
-      .then(data => {
-        const patientKey = data.patient_key
+      fetch(
+        `${apiBaseUrl}/Auth?` +
+          new URLSearchParams({
+            key: config.apiKey,
+            patient: config.patientId,
+          })
+      )
+        .then(res => res.json())
+        .then(data => {
+          const patientKey = data.patient_key
 
-        Scheduler.init({
-          api: apiBaseUrl,
-          appointmentCoding: {
-            code: 'CODE',
-            system: "http://snomed.info/sct"
-          },
-          bailoutURL: 'https://canvasmedical.com',
-          callbacks: callbacks,
-          daysToFetch: '7',
-          duration: '60',
-          locationId: '1',
-          patientId: config.patientId,
-          patientKey: patientKey,
-          providerIds: config.providerIds,
-          reason: 'high fever, cough, leeches',
-          returnURL: 'https://canvasmedical.com',
-          rootId: 'embed-root',
-          // brandColor: '',
-          // accentColor: '',
-          // customFont: 'Nunito',
+          Scheduler.init({
+            api: apiBaseUrl,
+            appointmentCoding: {
+              code: 'CODE',
+              system: 'http://snomed.info/sct',
+            },
+            bailoutURL: 'https://canvasmedical.com',
+            callbacks: callbacks,
+            daysToFetch: '7',
+            duration: '60',
+            locationId: '1',
+            patientId: config.patientId,
+            patientKey: patientKey,
+            providerIds: config.providerIds,
+            reason: 'high fever, cough, leeches',
+            returnURL: 'https://canvasmedical.com',
+            rootId: 'embed-root',
+            // brandColor: '',
+            // accentColor: '',
+            // customFont: 'Nunito',
+          })
         })
-      }).catch(e => {
-        console.error(e)
-      })
+        .catch(e => {
+          console.error(e)
+        })
     </script>
   </body>
 </html>

--- a/clients/scheduler/src/utils/types.ts
+++ b/clients/scheduler/src/utils/types.ts
@@ -17,7 +17,7 @@ export interface IMainAppProps {
       config?: Record<string, any>
     ) => void
     onChange: (
-      e: React.MouseEvent<HTMLButtonElement>,
+      e: React.ChangeEvent<HTMLSelectElement>,
       config?: Record<string, any>
     ) => void
     onError: () => void

--- a/clients/scheduler/src/utils/types.ts
+++ b/clients/scheduler/src/utils/types.ts
@@ -1,6 +1,5 @@
 import {
   AppointmentCodingType,
-  CallbackType,
   GeneratedColorsType,
   ProvidersType,
   SetTimeSlotsType,
@@ -12,7 +11,17 @@ export interface IMainAppProps {
   appointmentBufferInMintues: number
   appointmentCoding: AppointmentCodingType
   bailoutURL: string
-  callbacks: Record<string, CallbackType>
+  callbacks: {
+    onClick: (
+      e: React.MouseEvent<HTMLButtonElement>,
+      config?: Record<string, any>
+    ) => void
+    onChange: (
+      e: React.MouseEvent<HTMLButtonElement>,
+      config?: Record<string, any>
+    ) => void
+    onError: () => void
+  }
   daysToFetch: number
   duration: number
   locationId: string
@@ -40,7 +49,6 @@ export interface ISchedulerProps extends IMainAppProps, IInitializerOnlyProps {
 }
 
 export interface IAppContext extends IMainAppProps {
-  callbacks: Record<string, CallbackType>
   colors: GeneratedColorsType
   shadowRoot: any
   date: Date


### PR DESCRIPTION
Add callback support for various events in the scheduler.

- After back and forth with Louis and Josh, this seems like the most appropriate solution to handle click events in the scheduler.
- We are creating 3 callbacks, and cleaning up some other callbacks.
- We leverage `data-analytics-id` to help Jade identify what is get clicked on.
- `onError` is still in progress