### PR TITLE
ACAI-894: account appointments display update

### DIFF
--- a/clients/appointments/src/components/index.tsx
+++ b/clients/appointments/src/components/index.tsx
@@ -16,6 +16,7 @@ import { Ui } from './ui'
 const defaultAppointment: AppointmentType = {
   id: '',
   code: '',
+  description: '',
   display: '',
   locationId: '',
   providerId: '',

--- a/clients/appointments/src/components/ui.tsx
+++ b/clients/appointments/src/components/ui.tsx
@@ -46,6 +46,10 @@ export const Ui = ({
     <Body>
       {appointments.length ? (
         appointments.map(appointment => {
+          const validDescription =
+            appointment.description &&
+            appointment.description.length > 0 &&
+            appointment.description !== 'No description given'
           const appointmentDate = new Date(appointment.start)
           const dateString = `${formatDate(appointmentDate)} at ${formatTime(
             appointmentDate
@@ -63,7 +67,11 @@ export const Ui = ({
                 <H3>{dateString}</H3>
               </Box>
               <Box my="8px">
-                <Span>{`${appointment.display} with ${provider}`}</Span>
+                <Span>{`${
+                  validDescription
+                    ? appointment.description
+                    : appointment.display
+                } with ${provider}`}</Span>
               </Box>
               <Box>
                 <Button

--- a/clients/common/src/api/get-appointments-list/index.ts
+++ b/clients/common/src/api/get-appointments-list/index.ts
@@ -29,6 +29,7 @@ export const parseAppointments = ({
             parsedAppointments.push({
               id: resource.id,
               code: resource.appointmentType.coding[0].code || '',
+              description: resource.description || '',
               display: resource.appointmentType.coding[0].display || '',
               locationId:
                 resource.supportingInformation[0].reference.split('/')[1] || '',
@@ -51,6 +52,7 @@ export const parseAppointments = ({
         parsedAppointments.push({
           id: resource.id,
           code: resource.appointmentType.coding[0].code || '',
+          description: resource.description || '',
           display: resource.appointmentType.coding[0].display || '',
           locationId:
             resource.supportingInformation[0].reference.split('/')[1] || '',

--- a/clients/common/src/utils/types/index.ts
+++ b/clients/common/src/utils/types/index.ts
@@ -29,6 +29,7 @@ export type TimeSlotType = {
 export type AppointmentType = {
   id: string
   code: string
+  description: string
   display: string
   locationId?: string
   providerId: string


### PR DESCRIPTION
- Setting the `description` field inside of `parseAppointments`
- Updating appointments ui to conditionally render the `appointment.description` if valid, otherwise fallback to current `appointment.display`