### PR TITLE
ACAI - 1298 rework

### DIFF
--- a/clients/appointments/src/components/index.tsx
+++ b/clients/appointments/src/components/index.tsx
@@ -14,6 +14,8 @@ import {
 import { IAppProps } from '../utils'
 import { Ui } from './ui'
 
+const noOp = () => {}
+
 const defaultAppointment: AppointmentType = {
   id: '',
   code: '',
@@ -44,13 +46,14 @@ export const AppointmentsView = ({
 
   const [appointments, setAppointments] = useState<AppointmentType[]>([])
   const [providers, setProviders] = useState<ProvidersType[]>([])
+  const [initialized, setInitialized] = useState<boolean>(false)
 
   const handleCancel = (appointment: AppointmentType) => {
     setAppointmentCancellation({ popoverOpen: true, appointment })
   }
 
   const handleError: HandleErrorType = (error, msg) => {
-    callbacks.onError(error, msg)
+    callbacks?.onError(error, msg)
     setError(msg)
   }
 
@@ -64,6 +67,9 @@ export const AppointmentsView = ({
       api,
       patientId,
       patientKey,
+      initialized,
+      setInitialized,
+      onLoad: callbacks?.onLoad || noOp,
     })
   }, [api, patientId, patientKey, providerIds])
 

--- a/clients/appointments/src/index.html
+++ b/clients/appointments/src/index.html
@@ -43,6 +43,7 @@
         onError: (error, msg) => {
           // console.error('error', error, msg)
         },
+        onLoad: () => {},
       }
 
       const config = {

--- a/clients/appointments/src/utils/types.ts
+++ b/clients/appointments/src/utils/types.ts
@@ -15,6 +15,7 @@ export interface IMainAppProps {
       config?: Record<string, any>
     ) => void
     onError: HandleErrorType
+    onLoad: () => void
   }
   locationId: string
   patientId: string

--- a/clients/common/src/api/get-appointments-list/index.ts
+++ b/clients/common/src/api/get-appointments-list/index.ts
@@ -17,6 +17,9 @@ export const parseAppointments = ({
   providerAppointments,
   patientId,
   patientKey,
+  initialized,
+  setInitialized,
+  onLoad,
 }: ParseAppointmentsParamsType) => {
   const parsedAppointments: AppointmentType[] = []
   const parsedProviders: string[] = []
@@ -75,6 +78,9 @@ export const parseAppointments = ({
     providerIds: parsedProviders,
     patientId,
     patientKey,
+    initialized,
+    setInitialized,
+    onLoad,
   })
 }
 
@@ -88,6 +94,9 @@ export const getAppointmentsList = ({
   patientId,
   patientKey,
   providerIds,
+  initialized,
+  setInitialized,
+  onLoad,
 }: GetAppointmentsListParamsType) => {
   setLoading(true)
 
@@ -118,6 +127,9 @@ export const getAppointmentsList = ({
           providerAppointments: responses,
           patientId,
           patientKey,
+          initialized,
+          setInitialized,
+          onLoad,
         })
       )
       .catch(e => onError(e, 'Error Fetching Appointments'))
@@ -140,6 +152,9 @@ export const getAppointmentsList = ({
           appointments: response.data,
           patientId,
           patientKey,
+          initialized,
+          setInitialized,
+          onLoad,
         })
       })
       .catch(e => onError(e, 'Error Fetching Appointments'))

--- a/clients/common/src/api/get-appointments-list/types.ts
+++ b/clients/common/src/api/get-appointments-list/types.ts
@@ -21,6 +21,9 @@ export type GetAppointmentsListParamsType = {
   patientId: string
   patientKey: string
   providerIds?: string[]
+  initialized: boolean
+  setInitialized: (isInitialized: boolean) => void
+  onLoad: () => void
 }
 
 export type ParseAppointmentsParamsType = {
@@ -33,4 +36,7 @@ export type ParseAppointmentsParamsType = {
   providerAppointments?: ProviderAppointmentsType
   patientId: string
   patientKey: string
+  initialized: boolean
+  setInitialized: (isInitialized: boolean) => void
+  onLoad: () => void
 }

--- a/clients/common/src/api/get-practitioners/index.ts
+++ b/clients/common/src/api/get-practitioners/index.ts
@@ -11,7 +11,9 @@ export const parsePractitioners = ({
   setProviders,
   providerIds,
   providers,
-  onTimeslotLoad,
+  onLoad,
+  initialized,
+  setInitialized,
 }: ParsePractitionersParmsType) => {
   const parsedProviders: ProvidersType[] = []
 
@@ -27,7 +29,11 @@ export const parsePractitioners = ({
     })
   }
 
-  onTimeslotLoad()
+  if (!initialized) {
+    onLoad()
+    setInitialized(true)
+  }
+
   setProviders(parsedProviders)
   setLoading(false)
 }
@@ -40,7 +46,9 @@ export const getPractitioners = ({
   providerIds,
   patientId,
   patientKey,
-  onTimeslotLoad,
+  onLoad,
+  initialized,
+  setInitialized,
 }: GetPractitionersParamsType) => {
   setLoading(true)
 
@@ -57,7 +65,9 @@ export const getPractitioners = ({
         setProviders,
         providerIds,
         providers: response.data,
-        onTimeslotLoad,
+        onLoad,
+        initialized,
+        setInitialized,
       })
     })
     .catch(e => onError(e, 'Error Fetching Providers'))

--- a/clients/common/src/api/get-practitioners/types.ts
+++ b/clients/common/src/api/get-practitioners/types.ts
@@ -32,7 +32,9 @@ export type GetPractitionersParamsType = {
   providerIds: string[]
   patientId: string
   patientKey: string
-  onTimeslotLoad: () => void
+  onLoad: () => void
+  initialized: boolean
+  setInitialized: (isInitialized: boolean) => void
 }
 
 export type ParsePractitionersParmsType = {
@@ -40,5 +42,7 @@ export type ParsePractitionersParmsType = {
   setProviders: (providers: ProvidersType[]) => void
   providerIds: string[]
   providers: IGetPractitionersResponse
-  onTimeslotLoad: () => void
+  onLoad: () => void
+  initialized: boolean
+  setInitialized: (isInitialized: boolean) => void
 }

--- a/clients/common/src/api/get-slots/index.ts
+++ b/clients/common/src/api/get-slots/index.ts
@@ -19,7 +19,9 @@ export const parseSlots = ({
   providerIds,
   patientId,
   patientKey,
-  onTimeslotLoad,
+  onLoad,
+  initialized,
+  setInitialized,
 }: ParseSlotsParamsType): void => {
   const slots: ParsedSlotsType[] = []
   responses.forEach((response: any) => {
@@ -47,7 +49,9 @@ export const parseSlots = ({
     providerIds,
     patientId,
     patientKey,
-    onTimeslotLoad,
+    onLoad,
+    initialized,
+    setInitialized,
   })
 }
 
@@ -64,7 +68,9 @@ export const getTimeSlots = ({
   patientKey,
   providerIds,
   setProviders,
-  onTimeslotLoad,
+  onLoad,
+  initialized,
+  setInitialized,
 }: GetSlotsParamsType) => {
   setLoading(true)
 
@@ -98,7 +104,9 @@ export const getTimeSlots = ({
         providerIds,
         patientId,
         patientKey,
-        onTimeslotLoad,
+        onLoad,
+        initialized,
+        setInitialized,
       })
     )
     .catch(e => onError(e, 'Error Fetching Appointments'))

--- a/clients/common/src/api/get-slots/types.ts
+++ b/clients/common/src/api/get-slots/types.ts
@@ -19,7 +19,9 @@ export type GetSlotsParamsType = {
   providerIds: string[]
   setProviders: (providers: ProvidersType[]) => void
   daysToFetch: number
-  onTimeslotLoad: () => void
+  onLoad: () => void
+  initialized: boolean
+  setInitialized: (isInitialized: boolean) => void
 }
 
 type SlotResourceType = {
@@ -53,5 +55,7 @@ export type ParseSlotsParamsType = {
   patientKey: string
   providerIds: string[]
   setProviders: (providers: ProvidersType[]) => void
-  onTimeslotLoad: () => void
+  onLoad: () => void
+  initialized: boolean
+  setInitialized: (isInitialized: boolean) => void
 }

--- a/clients/scheduler/src/hooks/app-context.tsx
+++ b/clients/scheduler/src/hooks/app-context.tsx
@@ -29,7 +29,7 @@ export const AppContext = createContext<IAppContext>({
     onClick: noOp,
     onChange: noOp,
     onError: noOp,
-    onTimeslotLoad: noOp,
+    onLoad: noOp,
     overrideTimeSlotSelect: undefined,
   },
   daysToFetch: 7,
@@ -43,8 +43,8 @@ export const AppContext = createContext<IAppContext>({
     end: '',
     provider: {
       id: '',
-      name: ''
-    }
+      name: '',
+    },
   },
   description: '',
   returnURL: '',
@@ -88,6 +88,7 @@ export const ContextWrapper = ({ children, values }: ContextWrapperProps) => {
       id: '',
     },
   })
+  const [initialized, setInitialized] = useState<boolean>(false)
 
   const handleError: HandleErrorType = (error, msg) => {
     values.callbacks?.onError(error, msg)
@@ -120,7 +121,9 @@ export const ContextWrapper = ({ children, values }: ContextWrapperProps) => {
         setTimeSlots,
         setProviders,
         daysToFetch: values.daysToFetch,
-        onTimeslotLoad: values.callbacks?.onTimeslotLoad || noOp,
+        onLoad: values.callbacks?.onLoad || noOp,
+        initialized,
+        setInitialized,
       })
     },
     [date, values]

--- a/clients/scheduler/src/index.html
+++ b/clients/scheduler/src/index.html
@@ -48,7 +48,7 @@
         onError: (error, msg) => {
           // console.error('error', error, msg)
         },
-        onTimeslotLoad: () => {},
+        onLoad: () => {},
       }
 
       const config = {

--- a/clients/scheduler/src/utils/types.ts
+++ b/clients/scheduler/src/utils/types.ts
@@ -26,7 +26,7 @@ export interface IMainAppProps {
       e: React.ChangeEvent<HTMLSelectElement>,
       config?: Record<string, any>
     ) => void
-    onTimeslotLoad: () => void
+    onLoad: () => void
   }
   daysToFetch: number
   duration: number
@@ -34,7 +34,7 @@ export interface IMainAppProps {
   patientId: string
   patientKey: string
   providerIds: string[]
-  preloadBookingDate: { start: string, end: string }
+  preloadBookingDate: { start: string; end: string }
   preloadBookingDuration: string
   preloadProvider: ProvidersType
   description: string


### PR DESCRIPTION
We have to manage whether or not the scheduler has loaded into the embed instead of managing the logic at a Jade level. This is because the Scheduler is technically not a react component (although it is built with react). We only call the init function once in Jade, so our state references don't get passed to the scheduler. 

Hopefully that made sense, I can hop on a call and go further into the details if you'd like. 