### PR TITLE
send appropriate code to cancel appointment

### DIFF
--- a/clients/appointments/package.json
+++ b/clients/appointments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canvas-medical/embed-appointments",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "main": "dist/appointments.js",
   "license": "MIT",

--- a/clients/appointments/src/components/index.tsx
+++ b/clients/appointments/src/components/index.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useState } from 'preact/hooks'
 import {
   AppointmentType,
   getAppointmentsList,
-  getAppointmentType,
   Loader,
   putAppointment,
   Error,
@@ -87,7 +86,7 @@ export const AppointmentsView = ({
       onError: handleError,
       setLoading,
       appointmentCoding: {
-        code: getAppointmentType(appointmentCancellation.appointment.code),
+        code: appointmentCancellation.appointment.code,
       },
       locationId: appointmentCancellation.appointment.locationId || locationId,
       timeSlot: {

--- a/clients/appointments/src/components/index.tsx
+++ b/clients/appointments/src/components/index.tsx
@@ -54,6 +54,7 @@ export const AppointmentsView = ({
   const handleError: HandleErrorType = (error, msg) => {
     callbacks?.onError?.(error, msg)
     setError(msg)
+    setLoading(false)
   }
 
   const fetchAppointments = useCallback(() => {

--- a/clients/appointments/src/components/index.tsx
+++ b/clients/appointments/src/components/index.tsx
@@ -52,7 +52,7 @@ export const AppointmentsView = ({
   }
 
   const handleError: HandleErrorType = (error, msg) => {
-    callbacks?.onError(error, msg)
+    callbacks?.onError?.(error, msg)
     setError(msg)
   }
 
@@ -81,26 +81,31 @@ export const AppointmentsView = ({
   }
 
   const onCancel = () => {
-    putAppointment({
-      onComplete: afterCancel,
-      onError: handleError,
-      setLoading,
-      appointmentCoding: {
-        code: appointmentCancellation.appointment.code,
-      },
-      locationId: appointmentCancellation.appointment.locationId || locationId,
-      timeSlot: {
-        start: appointmentCancellation.appointment.start,
-        end: appointmentCancellation.appointment.end,
-        provider: {
-          id: appointmentCancellation.appointment.providerId,
+    try {
+      putAppointment({
+        onComplete: afterCancel,
+        onError: handleError,
+        setLoading,
+        appointmentCoding: {
+          code: appointmentCancellation.appointment.code,
         },
-      },
-      patientId,
-      patientKey,
-      api,
-      appointmentId: appointmentCancellation.appointment.id,
-    })
+        locationId:
+          appointmentCancellation.appointment.locationId || locationId,
+        timeSlot: {
+          start: appointmentCancellation.appointment.start,
+          end: appointmentCancellation.appointment.end,
+          provider: {
+            id: appointmentCancellation.appointment.providerId,
+          },
+        },
+        patientId,
+        patientKey,
+        api,
+        appointmentId: appointmentCancellation.appointment.id,
+      })
+    } catch (e) {
+      handleError(e as Error, 'Error Cancelling Appointment')
+    }
   }
 
   const onKeep = () => {

--- a/clients/appointments/src/components/index.tsx
+++ b/clients/appointments/src/components/index.tsx
@@ -2,6 +2,7 @@ import { h } from 'preact'
 import { useCallback, useEffect, useState } from 'preact/hooks'
 import {
   AppointmentType,
+  defaultAppointmentType,
   getAppointmentsList,
   Loader,
   putAppointment,
@@ -11,6 +12,7 @@ import {
   ProvidersType,
 } from '@canvas-medical/embed-common'
 import { IAppProps } from '../utils'
+
 import { Ui } from './ui'
 
 const noOp = () => {}
@@ -88,7 +90,9 @@ export const AppointmentsView = ({
         onError: handleError,
         setLoading,
         appointmentCoding: {
-          code: appointmentCancellation.appointment.code,
+          code:
+            appointmentCancellation?.appointment?.code ||
+            defaultAppointmentType.code,
         },
         locationId:
           appointmentCancellation.appointment.locationId || locationId,

--- a/clients/scheduler/src/index.html
+++ b/clients/scheduler/src/index.html
@@ -77,8 +77,9 @@
           Scheduler.init({
             api: apiBaseUrl,
             appointmentCoding: {
-              code: 'CODE',
+              code: '308335008',
               system: 'http://snomed.info/sct',
+              display: 'Office Visit',
             },
             bailoutURL: 'https://canvasmedical.com',
             callbacks: callbacks,


### PR DESCRIPTION
This fixes the issue where user's cannot cancel their appointments. There are a couple item that should be noted.

- `getAppointmentType` uses a hardcoded list of appointments and returns the `type` of appointment. 
This list is:

```
export const appointmentTypes = [
  {
    type: 'Home Visit',
    code: '439708006',
  },
  {
    type: 'Telemedicine',
    code: '448337001',
  },
  {
    type: 'Lab Visit',
    code: '31108002',
  },
  {
    type: 'Phone Call',
    code: '185317003',
  },
  {
  type: 'Office Visit',
  code: '308335008',
  },
]
```

This code has existed since we inherited the embed. This leads me to believe that Canvas updated their API to look at the `code` in the network requests. 
Updated error state when a cancel appointment call fails. 
<img width="367" alt="Screen Shot 2022-08-15 at 9 55 10 AM" src="https://user-images.githubusercontent.com/8423937/184683294-55bf481a-c4c2-42db-9fb9-4bd34110b0a4.png">

