### PR TITLE
ACAI-1348-a: Refactor `onLoad` callback 

### DIFF
--- a/clients/appointments/src/components/index.tsx
+++ b/clients/appointments/src/components/index.tsx
@@ -48,6 +48,7 @@ export const AppointmentsView = ({
   const [appointments, setAppointments] = useState<AppointmentType[]>([])
   const [providers, setProviders] = useState<ProvidersType[]>([])
   const [initialized, setInitialized] = useState<boolean>(false)
+  const [loadStartTime] = useState(new Date())
 
   const handleCancel = (appointment: AppointmentType) => {
     setAppointmentCancellation({ popoverOpen: true, appointment })
@@ -59,6 +60,13 @@ export const AppointmentsView = ({
     setLoading(false)
   }
 
+  useEffect(() => {
+    if (!loading && !initialized) {
+      setInitialized(true)
+      callbacks?.onLoad?.((new Date().getTime() - loadStartTime.getTime()) / 1000)
+    }
+  }, [loading, initialized])
+
   const fetchAppointments = useCallback(() => {
     getAppointmentsList({
       setLoading,
@@ -69,11 +77,8 @@ export const AppointmentsView = ({
       api,
       patientId,
       patientKey,
-      initialized,
-      setInitialized,
-      onLoad: callbacks?.onLoad || noOp,
     })
-  }, [api, patientId, patientKey, providerIds, initialized])
+  }, [api, patientId, patientKey, providerIds])
 
   const afterCancel = () => {
     setAppointmentCancellation({

--- a/clients/appointments/src/components/index.tsx
+++ b/clients/appointments/src/components/index.tsx
@@ -63,7 +63,7 @@ export const AppointmentsView = ({
   useEffect(() => {
     if (!loading && !initialized) {
       setInitialized(true)
-      callbacks?.onLoad?.((new Date().getTime() - loadStartTime.getTime()) / 1000)
+      callbacks?.onLoad?.((new Date().getTime() - loadStartTime.getTime()))
     }
   }, [loading, initialized])
 

--- a/clients/appointments/src/index.html
+++ b/clients/appointments/src/index.html
@@ -43,8 +43,8 @@
         onError: (error, msg) => {
           // console.error('error', error, msg)
         },
-        onLoad: (loadTime) => {
-          // console.log(`Appointments loaded in ${loadTime}s`)
+        onLoad: (loadTimeInMs) => {
+          // console.log(`Appointments loaded in ${loadTimeInMs}`)
         },
       }
 

--- a/clients/appointments/src/index.html
+++ b/clients/appointments/src/index.html
@@ -43,7 +43,9 @@
         onError: (error, msg) => {
           // console.error('error', error, msg)
         },
-        onLoad: () => {},
+        onLoad: (loadTime) => {
+          // console.log(`Appointments loaded in ${loadTime}s`)
+        },
       }
 
       const config = {

--- a/clients/appointments/src/utils/types.ts
+++ b/clients/appointments/src/utils/types.ts
@@ -15,7 +15,7 @@ export interface IMainAppProps {
       config?: Record<string, any>
     ) => void
     onError: HandleErrorType
-    onLoad: () => void
+    onLoad: (loadTime: number) => void
   }
   locationId: string
   patientId: string

--- a/clients/common/src/api/get-appointments-list/index.ts
+++ b/clients/common/src/api/get-appointments-list/index.ts
@@ -8,7 +8,6 @@ import {
 } from './types'
 
 export const parseAppointments = ({
-  setLoading,
   onError,
   setAppointments,
   setProviders,
@@ -17,9 +16,6 @@ export const parseAppointments = ({
   providerAppointments,
   patientId,
   patientKey,
-  initialized,
-  setInitialized,
-  onLoad,
 }: ParseAppointmentsParamsType) => {
   const parsedAppointments: AppointmentType[] = []
   const parsedProviders: string[] = []
@@ -71,21 +67,16 @@ export const parseAppointments = ({
 
   setAppointments(parsedAppointments)
   getPractitioners({
-    setLoading,
     onError,
     setProviders,
     api,
     providerIds: parsedProviders,
     patientId,
     patientKey,
-    initialized,
-    setInitialized,
-    onLoad,
   })
 }
 
 export const getAppointmentsList = ({
-  setLoading,
   onError,
   setAppointments,
   setProviders,
@@ -94,12 +85,7 @@ export const getAppointmentsList = ({
   patientId,
   patientKey,
   providerIds,
-  initialized,
-  setInitialized,
-  onLoad,
 }: GetAppointmentsListParamsType) => {
-  setLoading(true)
-
   if (providerIds) {
     Promise.all(
       providerIds.map(providerId => {
@@ -119,7 +105,6 @@ export const getAppointmentsList = ({
     )
       .then(responses =>
         parseAppointments({
-          setLoading,
           onError,
           setAppointments,
           setProviders,
@@ -127,9 +112,6 @@ export const getAppointmentsList = ({
           providerAppointments: responses,
           patientId,
           patientKey,
-          initialized,
-          setInitialized,
-          onLoad,
         })
       )
       .catch(e => onError(e, 'Error Fetching Appointments'))
@@ -144,7 +126,6 @@ export const getAppointmentsList = ({
       })
       .then(response => {
         parseAppointments({
-          setLoading,
           onError,
           setAppointments,
           setProviders,
@@ -152,9 +133,6 @@ export const getAppointmentsList = ({
           appointments: response.data,
           patientId,
           patientKey,
-          initialized,
-          setInitialized,
-          onLoad,
         })
       })
       .catch(e => onError(e, 'Error Fetching Appointments'))

--- a/clients/common/src/api/get-appointments-list/types.ts
+++ b/clients/common/src/api/get-appointments-list/types.ts
@@ -12,7 +12,6 @@ export type ProviderAppointmentsType = {
 }[]
 
 export type GetAppointmentsListParamsType = {
-  setLoading: SetLoadingType
   onError: HandleErrorType
   setAppointments: (appointments: AppointmentType[]) => void
   setProviders: (providers: ProvidersType[]) => void
@@ -21,13 +20,9 @@ export type GetAppointmentsListParamsType = {
   patientId: string
   patientKey: string
   providerIds?: string[]
-  initialized: boolean
-  setInitialized: (isInitialized: boolean) => void
-  onLoad: () => void
 }
 
 export type ParseAppointmentsParamsType = {
-  setLoading: SetLoadingType
   onError: HandleErrorType
   setAppointments: (appointments: AppointmentType[]) => void
   setProviders: (providers: ProvidersType[]) => void
@@ -36,7 +31,4 @@ export type ParseAppointmentsParamsType = {
   providerAppointments?: ProviderAppointmentsType
   patientId: string
   patientKey: string
-  initialized: boolean
-  setInitialized: (isInitialized: boolean) => void
-  onLoad: () => void
 }

--- a/clients/common/src/api/get-appointments-list/types.ts
+++ b/clients/common/src/api/get-appointments-list/types.ts
@@ -12,6 +12,7 @@ export type ProviderAppointmentsType = {
 }[]
 
 export type GetAppointmentsListParamsType = {
+  setLoading: SetLoadingType
   onError: HandleErrorType
   setAppointments: (appointments: AppointmentType[]) => void
   setProviders: (providers: ProvidersType[]) => void
@@ -23,6 +24,7 @@ export type GetAppointmentsListParamsType = {
 }
 
 export type ParseAppointmentsParamsType = {
+  setLoading: SetLoadingType
   onError: HandleErrorType
   setAppointments: (appointments: AppointmentType[]) => void
   setProviders: (providers: ProvidersType[]) => void

--- a/clients/common/src/api/get-practitioners/index.ts
+++ b/clients/common/src/api/get-practitioners/index.ts
@@ -7,13 +7,9 @@ import {
 } from './types'
 
 export const parsePractitioners = ({
-  setLoading,
   setProviders,
   providerIds,
   providers,
-  onLoad,
-  initialized,
-  setInitialized,
 }: ParsePractitionersParmsType) => {
   const parsedProviders: ProvidersType[] = []
 
@@ -29,29 +25,17 @@ export const parsePractitioners = ({
     })
   }
 
-  if (!initialized) {
-    onLoad()
-    setInitialized(true)
-  }
-
   setProviders(parsedProviders)
-  setLoading(false)
 }
 
 export const getPractitioners = ({
-  setLoading,
   onError,
   setProviders,
   api,
   providerIds,
   patientId,
   patientKey,
-  onLoad,
-  initialized,
-  setInitialized,
 }: GetPractitionersParamsType) => {
-  setLoading(true)
-
   axios
     .get<IGetPractitionersResponse>(`${api}/Practitioner`, {
       params: {
@@ -61,13 +45,9 @@ export const getPractitioners = ({
     })
     .then(response => {
       parsePractitioners({
-        setLoading,
         setProviders,
         providerIds,
         providers: response.data,
-        onLoad,
-        initialized,
-        setInitialized,
       })
     })
     .catch(e => onError(e, 'Error Fetching Providers'))

--- a/clients/common/src/api/get-practitioners/index.ts
+++ b/clients/common/src/api/get-practitioners/index.ts
@@ -28,7 +28,7 @@ export const parsePractitioners = ({
   setProviders(parsedProviders)
 }
 
-export const getPractitioners = ({
+export const getPractitioners = async ({
   onError,
   setProviders,
   api,
@@ -36,7 +36,7 @@ export const getPractitioners = ({
   patientId,
   patientKey,
 }: GetPractitionersParamsType) => {
-  axios
+  return axios
     .get<IGetPractitionersResponse>(`${api}/Practitioner`, {
       params: {
         patient: patientId,

--- a/clients/common/src/api/get-practitioners/types.ts
+++ b/clients/common/src/api/get-practitioners/types.ts
@@ -25,24 +25,16 @@ export interface IGetPractitionersResponse extends IFHIRResponse {
 }
 
 export type GetPractitionersParamsType = {
-  setLoading: SetLoadingType
   onError: HandleErrorType
   setProviders: (providers: ProvidersType[]) => void
   api: string
   providerIds: string[]
   patientId: string
   patientKey: string
-  onLoad: () => void
-  initialized: boolean
-  setInitialized: (isInitialized: boolean) => void
 }
 
 export type ParsePractitionersParmsType = {
-  setLoading: SetLoadingType
   setProviders: (providers: ProvidersType[]) => void
   providerIds: string[]
   providers: IGetPractitionersResponse
-  onLoad: () => void
-  initialized: boolean
-  setInitialized: (isInitialized: boolean) => void
 }

--- a/clients/common/src/api/get-slots/index.ts
+++ b/clients/common/src/api/get-slots/index.ts
@@ -47,9 +47,6 @@ export const getTimeSlots = ({
   patientKey,
   providerIds,
   setProviders,
-  onLoad,
-  initialized,
-  setInitialized,
 }: GetSlotsParamsType) => {
   setLoading(true)
 
@@ -83,9 +80,6 @@ export const getTimeSlots = ({
         providerIds,
         patientId,
         patientKey,
-        onLoad,
-        initialized,
-        setInitialized,
       })
     )
     .catch(e => onError(e, 'Error Fetching Appointments'))

--- a/clients/common/src/api/get-slots/index.ts
+++ b/clients/common/src/api/get-slots/index.ts
@@ -1,6 +1,5 @@
 import axios from 'axios'
 import { ParsedSlotsType, SlotType } from '../../utils'
-import { getPractitioners } from '../get-practitioners'
 import {
   GetSlotsParamsType,
   IGetSlotsResponse,
@@ -13,12 +12,6 @@ export const parseSlots = ({
   setLoading,
   responses,
   setTimeSlots,
-  onError,
-  setProviders,
-  api,
-  providerIds,
-  patientId,
-  patientKey,
   onLoad,
   initialized,
   setInitialized,
@@ -39,20 +32,14 @@ export const parseSlots = ({
     }
     slots.push({ providerId: response.providerId, providerSlots })
   })
-  setTimeSlots(slots)
 
-  getPractitioners({
-    setLoading,
-    onError,
-    setProviders,
-    api,
-    providerIds,
-    patientId,
-    patientKey,
-    onLoad,
-    initialized,
-    setInitialized,
-  })
+  setTimeSlots(slots)
+  setLoading(false)
+
+  if (!initialized) {
+    setInitialized(true)
+    onLoad()
+  }
 }
 
 export const getTimeSlots = ({

--- a/clients/common/src/api/get-slots/index.ts
+++ b/clients/common/src/api/get-slots/index.ts
@@ -12,9 +12,6 @@ export const parseSlots = ({
   setLoading,
   responses,
   setTimeSlots,
-  onLoad,
-  initialized,
-  setInitialized,
 }: ParseSlotsParamsType): void => {
   const slots: ParsedSlotsType[] = []
   responses.forEach((response: any) => {
@@ -35,11 +32,6 @@ export const parseSlots = ({
 
   setTimeSlots(slots)
   setLoading(false)
-
-  if (!initialized) {
-    setInitialized(true)
-    onLoad()
-  }
 }
 
 export const getTimeSlots = ({

--- a/clients/common/src/api/get-slots/types.ts
+++ b/clients/common/src/api/get-slots/types.ts
@@ -19,9 +19,6 @@ export type GetSlotsParamsType = {
   providerIds: string[]
   setProviders: (providers: ProvidersType[]) => void
   daysToFetch: number
-  onLoad: () => void
-  initialized: boolean
-  setInitialized: (isInitialized: boolean) => void
 }
 
 type SlotResourceType = {
@@ -55,7 +52,4 @@ export type ParseSlotsParamsType = {
   patientKey: string
   providerIds: string[]
   setProviders: (providers: ProvidersType[]) => void
-  onLoad: () => void
-  initialized: boolean
-  setInitialized: (isInitialized: boolean) => void
 }

--- a/clients/scheduler/src/App.tsx
+++ b/clients/scheduler/src/App.tsx
@@ -2,9 +2,14 @@ import { h } from 'preact'
 import { AppContainer, Body, Error, Header } from '@canvas-medical/embed-common'
 import { useAppContext } from './hooks'
 import { Confirmation, TimeSlotSelect } from './components'
+import { useEffect } from 'preact/hooks'
 
 export const App = () => {
-  const { bailoutURL, colors, screen, error, fontFamily } = useAppContext()
+  const { bailoutURL, colors, screen, error, fontFamily, fetchProviders } = useAppContext()
+
+  useEffect(() => {
+    fetchProviders()
+  }, [])
 
   return (
     <AppContainer fontFamily={fontFamily}>

--- a/clients/scheduler/src/App.tsx
+++ b/clients/scheduler/src/App.tsx
@@ -15,7 +15,7 @@ export const App = () => {
 
   useEffect(() => {
     if (initialized) {
-      onLoad((new Date().getTime() - loadStartTime.getTime()) / 1000)
+      onLoad((new Date().getTime() - loadStartTime.getTime()))
     }
   }, [initialized, loadStartTime])
 

--- a/clients/scheduler/src/App.tsx
+++ b/clients/scheduler/src/App.tsx
@@ -2,14 +2,22 @@ import { h } from 'preact'
 import { AppContainer, Body, Error, Header } from '@canvas-medical/embed-common'
 import { useAppContext } from './hooks'
 import { Confirmation, TimeSlotSelect } from './components'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 
 export const App = () => {
-  const { bailoutURL, colors, screen, error, fontFamily, fetchProviders } = useAppContext()
+  const { bailoutURL, colors, screen, error, fontFamily, fetchProviders, initialized, onLoad } = useAppContext()
+
+  const [loadStartTime] = useState(new Date())
 
   useEffect(() => {
     fetchProviders()
   }, [])
+
+  useEffect(() => {
+    if (initialized) {
+      onLoad((new Date().getTime() - loadStartTime.getTime()) / 1000)
+    }
+  }, [initialized, loadStartTime])
 
   return (
     <AppContainer fontFamily={fontFamily}>

--- a/clients/scheduler/src/components/time-slot-select/index.tsx
+++ b/clients/scheduler/src/components/time-slot-select/index.tsx
@@ -55,8 +55,12 @@ export const TimeSlotSelect = () => {
       )
 
       setProviderTimeSlots(mergedProviderAvailability)
+
+      if (!initialized) {
+        setInitialized(true)
+      }
     },
-    [providerTimeSlots]
+    [providerTimeSlots, initialized]
   )
 
   const { minDate, maxDate } = useMemo(() => {
@@ -93,9 +97,6 @@ export const TimeSlotSelect = () => {
   useEffect(() => {
     if (typeof maxDate === 'undefined' || date >= maxDate) {
       fetchTimeSlots(addTimeSlots)
-      if (!initialized) {
-        setInitialized(true)
-      }
     }
   }, [date])
 

--- a/clients/scheduler/src/components/time-slot-select/index.tsx
+++ b/clients/scheduler/src/components/time-slot-select/index.tsx
@@ -20,6 +20,7 @@ export const TimeSlotSelect = () => {
     appointmentBufferInMintues,
     preloadBooking,
     initialized,
+    setInitialized,
     providers,
     callbacks,
   } = useAppContext()
@@ -92,6 +93,9 @@ export const TimeSlotSelect = () => {
   useEffect(() => {
     if (typeof maxDate === 'undefined' || date >= maxDate) {
       fetchTimeSlots(addTimeSlots)
+      if (!initialized) {
+        setInitialized(true)
+      }
     }
   }, [date])
 

--- a/clients/scheduler/src/hooks/app-context.tsx
+++ b/clients/scheduler/src/hooks/app-context.tsx
@@ -12,6 +12,7 @@ import {
   TimeSlotType,
 } from '@canvas-medical/embed-common'
 import { IAppContext } from '../utils'
+import { getPractitioners } from '@canvas-medical/embed-common/src/api/get-practitioners'
 
 type ContextWrapperProps = {
   children: ComponentChildren
@@ -71,6 +72,7 @@ export const AppContext = createContext<IAppContext>({
   resetTimeSlot: noOp,
   fetchTimeSlots: noOp,
   fetchScheduledAppointment: noOp,
+  fetchProviders: noOp,
   createAppointment: noOp,
   cancelAppointment: noOp,
   initialized: false,
@@ -84,7 +86,6 @@ const blankTimeSlot = () => ({
     id: '',
   },
 })
-
 
 export const ContextWrapper = ({ children, values }: ContextWrapperProps) => {
   const [screen, setScreen] = useState<string>('SELECT')
@@ -179,6 +180,17 @@ export const ContextWrapper = ({ children, values }: ContextWrapperProps) => {
     [timeSlot, values]
   )
 
+  const fetchProviders = useCallback(() => {
+    getPractitioners({
+      onError: handleError,
+      setProviders,
+      api: values.api,
+      patientId: values.patientId,
+      patientKey: values.patientKey,
+      providerIds: values.providerIds,
+    })
+  }, [values])
+
   const contextValue = useMemo(() => {
     return {
       ...values,
@@ -195,9 +207,11 @@ export const ContextWrapper = ({ children, values }: ContextWrapperProps) => {
       resetTimeSlot,
       fetchTimeSlots,
       fetchScheduledAppointment,
+      fetchProviders,
       createAppointment,
       cancelAppointment,
       initialized,
+      setInitialized,
     }
   }, [screen, date, loading, error, timeSlot, initialized])
 

--- a/clients/scheduler/src/hooks/app-context.tsx
+++ b/clients/scheduler/src/hooks/app-context.tsx
@@ -76,6 +76,8 @@ export const AppContext = createContext<IAppContext>({
   createAppointment: noOp,
   cancelAppointment: noOp,
   initialized: false,
+  setInitialized: noOp,
+  onLoad: noOp
 })
 
 const blankTimeSlot = () => ({
@@ -122,9 +124,6 @@ export const ContextWrapper = ({ children, values }: ContextWrapperProps) => {
         setTimeSlots,
         setProviders,
         daysToFetch: values.daysToFetch,
-        onLoad: values.callbacks?.onLoad || noOp,
-        initialized,
-        setInitialized,
       })
     },
     [date, values, initialized]
@@ -212,6 +211,7 @@ export const ContextWrapper = ({ children, values }: ContextWrapperProps) => {
       cancelAppointment,
       initialized,
       setInitialized,
+      onLoad: values.callbacks?.onLoad || noOp,
     }
   }, [screen, date, loading, error, timeSlot, initialized])
 

--- a/clients/scheduler/src/index.html
+++ b/clients/scheduler/src/index.html
@@ -48,8 +48,8 @@
         onError: (error, msg) => {
           // console.error('error', error, msg)
         },
-        onLoad: (loadTime) => {
-          // console.log(`Scheduler Load Time: ${loadTime}`)
+        onLoad: (loadTimeInMs) => {
+          // console.log(`Scheduler Load Time: ${loadTimeInMs}`)
         },
         onDateChange: config => {
           // console.log(config, 'config')

--- a/clients/scheduler/src/index.html
+++ b/clients/scheduler/src/index.html
@@ -48,7 +48,9 @@
         onError: (error, msg) => {
           // console.error('error', error, msg)
         },
-        onLoad: () => {},
+        onLoad: (loadTime) => {
+          // console.log(`Scheduler Load Time: ${loadTime}`)
+        },
         onDateChange: config => {
           // console.log(config, 'config')
         },

--- a/clients/scheduler/src/utils/types.ts
+++ b/clients/scheduler/src/utils/types.ts
@@ -33,7 +33,7 @@ export interface IMainAppProps {
       e: React.ChangeEvent<HTMLSelectElement>,
       config?: Record<string, any>
     ) => void
-    onLoad: () => void
+    onLoad: (loadTime: number) => void
     onDateChange: (config: OnDateChangeParam) => void
   }
   daysToFetch: number
@@ -89,4 +89,5 @@ export interface IAppContext extends IMainAppProps {
   cancelAppointment: (appointmentId: string, onComplete: () => void) => void
   initialized: boolean
   setInitialized: (initialized: boolean) => void
+  onLoad: (loadTime: number) => void
 }

--- a/clients/scheduler/src/utils/types.ts
+++ b/clients/scheduler/src/utils/types.ts
@@ -33,7 +33,7 @@ export interface IMainAppProps {
       e: React.ChangeEvent<HTMLSelectElement>,
       config?: Record<string, any>
     ) => void
-    onLoad: (loadTime: number) => void
+    onLoad: (loadTime: string) => void
     onDateChange: (config: OnDateChangeParam) => void
   }
   daysToFetch: number

--- a/clients/scheduler/src/utils/types.ts
+++ b/clients/scheduler/src/utils/types.ts
@@ -84,7 +84,9 @@ export interface IAppContext extends IMainAppProps {
   fetchScheduledAppointment: (
     setAppointmentId: (appointmentId: string) => void
   ) => void
+  fetchProviders: () => void
   createAppointment: () => void
   cancelAppointment: (appointmentId: string, onComplete: () => void) => void
   initialized: boolean
+  setInitialized: (initialized: boolean) => void
 }

--- a/clients/scheduler/src/utils/types.ts
+++ b/clients/scheduler/src/utils/types.ts
@@ -33,7 +33,7 @@ export interface IMainAppProps {
       e: React.ChangeEvent<HTMLSelectElement>,
       config?: Record<string, any>
     ) => void
-    onLoad: (loadTime: string) => void
+    onLoad: (loadTimeInMs: number) => void
     onDateChange: (config: OnDateChangeParam) => void
   }
   daysToFetch: number
@@ -89,5 +89,5 @@ export interface IAppContext extends IMainAppProps {
   cancelAppointment: (appointmentId: string, onComplete: () => void) => void
   initialized: boolean
   setInitialized: (initialized: boolean) => void
-  onLoad: (loadTime: number) => void
+  onLoad: (loadTimeInMs: number) => void
 }


### PR DESCRIPTION
We now calculate the `onLoad` time within the embed. This should give us more accurate data on how long it takes for data to be loaded from the API and presented to the user.

Affected packages:
- scheduler
- appointments
- common