### PR TITLE
CHIA-149: Calendar month typos

### DIFF
--- a/clients/scheduler/src/utils/dates/calendar.ts
+++ b/clients/scheduler/src/utils/dates/calendar.ts
@@ -14,8 +14,8 @@ const monthStrings = [
   'August',
   'September',
   'October',
-  'Novemeber',
-  'Decemeber',
+  'November',
+  'December',
 ]
 
 export const getMonthAndYearOptions = (): MonthAndYearType[] => {


### PR DESCRIPTION
Fix typos for November and December in the calendar. 