### PR TITLE
Bump scheduler version to 0.1.91

### DIFF
--- a/clients/scheduler/CHANGELOG.md
+++ b/clients/scheduler/CHANGELOG.md
@@ -73,3 +73,9 @@
 ### Added
 
 - Updated the `resetTimeslot` function to reset preload booking data too
+
+## [0.1.91] - 2022-08-30
+
+### Changed
+
+- Fixed typos in the calendar (November and December)

--- a/clients/scheduler/package.json
+++ b/clients/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canvas-medical/embed-scheduler",
-  "version": "0.1.9",
+  "version": "0.1.91",
   "private": false,
   "main": "dist/scheduler.js",
   "license": "MIT",


### PR DESCRIPTION
Release embed-scheduler v0.1.91
fixes some calendar typos