### PR TITLE
ACAI-1744 Allow sorting of providers by number of available time slots per day

### DIFF
--- a/clients/scheduler/src/components/time-slot-select/index.tsx
+++ b/clients/scheduler/src/components/time-slot-select/index.tsx
@@ -23,6 +23,7 @@ export const TimeSlotSelect = () => {
     setInitialized,
     providers,
     callbacks,
+    sortProviders,
   } = useAppContext()
   const [providerTimeSlots, setProviderTimeSlots] = useState<ParsedSlotsType[]>(
     []
@@ -102,7 +103,7 @@ export const TimeSlotSelect = () => {
   }, [date])
 
   const dayOfTimeSlots = useMemo(() => {
-    return providerTimeSlots.map(provider => {
+    const sameDayTimeSlots = providerTimeSlots.map(provider => {
       return {
         providerId: provider.providerId,
         providerSlots: provider.providerSlots.filter(slot => {
@@ -110,6 +111,12 @@ export const TimeSlotSelect = () => {
         }),
       }
     })
+    if (sortProviders) {
+      sameDayTimeSlots.sort((a , b) => {
+        return b.providerSlots.length - a.providerSlots.length
+      })
+    }
+    return sameDayTimeSlots
   }, [date, providerTimeSlots])
 
   const previousInitializedValue = usePreviousValue(initialized)

--- a/clients/scheduler/src/hooks/app-context.tsx
+++ b/clients/scheduler/src/hooks/app-context.tsx
@@ -78,7 +78,8 @@ export const AppContext = createContext<IAppContext>({
   cancelAppointment: noOp,
   initialized: false,
   setInitialized: noOp,
-  onLoad: noOp
+  onLoad: noOp,
+  sortProviders: false,
 })
 
 const blankTimeSlot = () => ({

--- a/clients/scheduler/src/index.tsx
+++ b/clients/scheduler/src/index.tsx
@@ -28,7 +28,8 @@ export const Scheduler = (props: ISchedulerProps) => {
     shadowRoot,
     fontFamily,
     screen,
-    timeSlot
+    timeSlot,
+    sortProviders,
   } = props
   const colors = generateColors(brandColor, accentColor)
   const allValuesProvided = hasAllValues(props)
@@ -83,6 +84,7 @@ export const Scheduler = (props: ISchedulerProps) => {
             fetchScheduledAppointment: () => {},
             createAppointment: () => {},
             cancelAppointment: () => {},
+            sortProviders,
           }}
         >
           <App />
@@ -116,7 +118,8 @@ export const init = ({
   accentColor,
   fontFamily,
   screen,
-  timeSlot
+  timeSlot,
+  sortProviders,
 }: IInitializerProps) => {
   const appRoot = document.querySelector(`#${rootId}`)
 
@@ -162,6 +165,7 @@ export const init = ({
       fontFamily={fontFamily}
       screen={screen}
       timeSlot={timeSlot}
+      sortProviders={sortProviders}
     />,
     appRoot.shadowRoot
   )

--- a/clients/scheduler/src/utils/types.ts
+++ b/clients/scheduler/src/utils/types.ts
@@ -50,6 +50,7 @@ export interface IMainAppProps {
   description: string
   returnURL: string
   fontFamily?: string
+  sortProviders: boolean
 }
 
 interface IInitializerOnlyProps {


### PR DESCRIPTION
`sortProviders` will allow providers to be sorted by the number of available time slots they have per day