### PR TITLE
ACAI-2683: Add support for starting appointment dates

### DIFF
--- a/clients/scheduler/src/components/date-select/calendar/index.tsx
+++ b/clients/scheduler/src/components/date-select/calendar/index.tsx
@@ -4,7 +4,7 @@ import {
   getMonthAndYearOptions,
   getNextMonth,
   getPreviousMonth,
-  isTodayOrBefore,
+  isEarliestDateOrBefore,
   sameMonthAndYear,
 } from '../../../utils/dates'
 import { Ui } from './ui'
@@ -25,9 +25,10 @@ export const Calendar = ({
   const {
     callbacks: { onClick },
     date,
+    startDate,
     setDate,
   } = useAppContext()
-  const monthsAndYears = getMonthAndYearOptions()
+  const monthsAndYears = getMonthAndYearOptions(startDate)
 
   const backDisabled = sameMonthAndYear(date, monthsAndYears[0].date)
   const forwardDisabled = sameMonthAndYear(
@@ -56,8 +57,8 @@ export const Calendar = ({
 
     let newDate = new Date(year, month, day)
 
-    if (isTodayOrBefore(newDate)) {
-      newDate = new Date()
+    if (isEarliestDateOrBefore(newDate, startDate)) {
+      newDate = startDate || new Date()
     }
 
     setDate(newDate)

--- a/clients/scheduler/src/components/date-select/index.tsx
+++ b/clients/scheduler/src/components/date-select/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@canvas-medical/embed-common'
 import { useAppContext } from '../../hooks'
 import {
-  isTodayOrBefore,
+  isEarliestDateOrBefore,
   scrollDateBack,
   scrollDateForward,
   userTimezone,
@@ -30,9 +30,10 @@ export const DateSelect = ({ enabledDates, maxDate }: DateSelectPropsType) => {
     colors,
     date,
     setDate,
+    startDate,
   } = useAppContext()
   const [calendarOpen, setCalendarOpen] = useState(false)
-  const backDisabled = isTodayOrBefore(date)
+  const backDisabled = isEarliestDateOrBefore(date, startDate)
 
   useEffect(() => {
     const handleEsc = (event: any) => {
@@ -56,9 +57,9 @@ export const DateSelect = ({ enabledDates, maxDate }: DateSelectPropsType) => {
       onClick(e, { direction, date: newDate })
     }
     if (direction === 'back') {
-      scrollDateBack(date, callback)
+      scrollDateBack(date, callback, startDate)
     } else {
-      scrollDateForward(date, callback)
+      scrollDateForward(date, callback, startDate)
     }
   }
 

--- a/clients/scheduler/src/hooks/app-context.tsx
+++ b/clients/scheduler/src/hooks/app-context.tsx
@@ -11,7 +11,7 @@ import {
   HandleErrorType,
   TimeSlotType,
 } from '@canvas-medical/embed-common'
-import { IAppContext } from '../utils'
+import { IAppContext, isEarliestDateOrBefore } from '../utils'
 import { getPractitioners } from '@canvas-medical/embed-common/src/api/get-practitioners'
 
 type ContextWrapperProps = {
@@ -106,7 +106,13 @@ export const ContextWrapper = ({ children, values }: ContextWrapperProps) => {
         utcDate.getTime() + utcDate.getTimezoneOffset() * 60000
       )
 
-      return localDate
+      const today = new Date()
+
+      if (isEarliestDateOrBefore(localDate, today)) {
+        return today
+      } else {
+        return localDate
+      }
     } else {
       return null
     }

--- a/clients/scheduler/src/hooks/app-context.tsx
+++ b/clients/scheduler/src/hooks/app-context.tsx
@@ -55,6 +55,7 @@ export const AppContext = createContext<IAppContext>({
   shadowRoot: null,
   date: new Date(),
   setDate: noOp,
+  startDate: null,
   error: '',
   loading: false,
   screen: 'SELECT',
@@ -92,8 +93,28 @@ const blankTimeSlot = () => ({
 })
 
 export const ContextWrapper = ({ children, values }: ContextWrapperProps) => {
+  const getStartDateFromURL = () => {
+    const searchParams = new URLSearchParams(window.location.search)
+    const startDateParam = searchParams.get('startDate')
+    // ISO 8601 format (e.g., '2023-08-21')
+    if (startDateParam) {
+      // Create a new Date object in UTC
+      const utcDate = new Date(startDateParam + 'T00:00:00Z')
+
+      // Adjust the date to the local time zone to display correctly
+      const localDate = new Date(
+        utcDate.getTime() + utcDate.getTimezoneOffset() * 60000
+      )
+
+      return localDate
+    } else {
+      return null
+    }
+  }
+
+  const startDate = getStartDateFromURL()
   const [screen, setScreen] = useState<string>(values.screen)
-  const [date, setDate] = useState<Date>(new Date())
+  const [date, setDate] = useState<Date>(startDate || new Date())
   const [loading, setLoading] = useState<boolean>(false)
   const [error, setError] = useState<string | string[]>('')
   const [providers, setProviders] = useState<ProvidersType[]>([])
@@ -216,6 +237,7 @@ export const ContextWrapper = ({ children, values }: ContextWrapperProps) => {
       initialized,
       setInitialized,
       onLoad: values.callbacks?.onLoad || noOp,
+      startDate,
     }
   }, [screen, date, loading, error, timeSlot, providers, initialized])
 

--- a/clients/scheduler/src/utils/dates/calendar.ts
+++ b/clients/scheduler/src/utils/dates/calendar.ts
@@ -18,8 +18,10 @@ const monthStrings = [
   'December',
 ]
 
-export const getMonthAndYearOptions = (): MonthAndYearType[] => {
-  const date = new Date()
+export const getMonthAndYearOptions = (
+  startDate: Date | null
+): MonthAndYearType[] => {
+  const date = startDate || new Date()
   const year = date.getFullYear()
   const startMonth = date.getMonth()
   const months: MonthAndYearType[] = []
@@ -109,7 +111,11 @@ const getDaysInMonth = (date: Date) => {
   }
 }
 
-export const generateDays = (date: Date, enabledDates: Set<string>, maxDate?: Date) => {
+export const generateDays = (
+  date: Date,
+  enabledDates: Set<string>,
+  maxDate?: Date
+) => {
   const year = date.getFullYear()
   const month = date.getMonth()
   const daysInMonth = getDaysInMonth(date)
@@ -131,7 +137,11 @@ export const generateDays = (date: Date, enabledDates: Set<string>, maxDate?: Da
       const day = new Date(year, month, i)
       days.push({
         date: i,
-        disabled: (maxDate && maxDate < day) || enabledDates.has(day.toLocaleDateString()) ? false: true,
+        disabled:
+          (maxDate && maxDate < day) ||
+          enabledDates.has(day.toLocaleDateString())
+            ? false
+            : true,
         dateString: getDateString(year, month, i),
       })
     }

--- a/clients/scheduler/src/utils/dates/functions.ts
+++ b/clients/scheduler/src/utils/dates/functions.ts
@@ -1,36 +1,50 @@
-export const isTodayOrBefore = (date: Date): boolean => {
-  const today = new Date()
+export const isEarliestDateOrBefore = (
+  date: Date,
+  startDate: Date | null
+): boolean => {
+  const earliestDate = startDate || new Date()
 
   return (
-    date.getDate() <= today.getDate() &&
-    date.getMonth() <= today.getMonth() &&
-    date.getFullYear() <= today.getFullYear()
+    date.getFullYear() < earliestDate.getFullYear() ||
+    (date.getFullYear() === earliestDate.getFullYear() &&
+      date.getMonth() < earliestDate.getMonth()) ||
+    (date.getFullYear() === earliestDate.getFullYear() &&
+      date.getMonth() === earliestDate.getMonth() &&
+      date.getDate() <= earliestDate.getDate())
   )
 }
 
-export const scrollDateBack = (date: Date, setter: Function): void => {
+export const scrollDateBack = (
+  date: Date,
+  setter: Function,
+  startDate: Date | null
+): void => {
   const year = date.getFullYear()
   const month = date.getMonth()
   const day = date.getDate() - 1
 
   const newDate = new Date(year, month, day)
 
-  if (isTodayOrBefore(newDate)) {
-    setter(new Date())
+  if (isEarliestDateOrBefore(newDate, startDate)) {
+    setter(startDate || new Date())
   } else {
     setter(new Date(year, month, day))
   }
 }
 
-export const scrollDateForward = (date: Date, setter: Function): void => {
+export const scrollDateForward = (
+  date: Date,
+  setter: Function,
+  startDate: Date | null
+): void => {
   const year = date.getFullYear()
   const month = date.getMonth()
   const day = date.getDate() + 1
 
   const newDate = new Date(year, month, day)
 
-  if (isTodayOrBefore(newDate)) {
-    setter(new Date())
+  if (isEarliestDateOrBefore(newDate, startDate)) {
+    setter(startDate || new Date())
   } else {
     setter(new Date(year, month, day))
   }

--- a/clients/scheduler/src/utils/types.ts
+++ b/clients/scheduler/src/utils/types.ts
@@ -8,7 +8,6 @@ import {
   SlotType,
 } from '@canvas-medical/embed-common'
 
-
 type OnDateChangeParam = {
   dayOfTimeSlots: { provider: ProvidersType; providerSlots: SlotType[] }[]
   isFirstDateViewed: boolean
@@ -75,6 +74,7 @@ export interface IAppContext extends IMainAppProps {
   shadowRoot: any
   date: Date
   setDate: (date: Date) => void
+  startDate: Date | null
   error: string | string[]
   loading: boolean
   screen: string


### PR DESCRIPTION
This PR accepts startDate params in order to support locking users to OP-specific times.